### PR TITLE
Support extracting logs from job URLs that have ?pr=123 query string

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -380,9 +381,13 @@ func getLogGroupArn(arn string) string {
 }
 
 func extractJobID(input string) string {
-	if strings.HasPrefix(input, "https://") {
-		// Extract job ID from URL like https://github.com/runs-on/runs-on/actions/runs/12312372848/job/34368864490
-		parts := strings.Split(input, "/")
+	url, err := url.Parse(input)
+	if err == nil && url.Scheme == "https" {
+		// Extract job ID from URLs like:
+		//
+		// - https://github.com/runs-on/runs-on/actions/runs/12312372848/job/34368864490
+		// - https://github.com/runs-on/runs-on/actions/runs/12312372848/job/34368864490?pr=123
+		parts := strings.Split(url.Path, "/")
 		if len(parts) > 1 {
 			return parts[len(parts)-1]
 		}


### PR DESCRIPTION
This makes the extract-from-URL job ID deduction for `roc logs 'https://...'` work when the URL has a query string or other trailing data.

This occurs in practice when clicking through to a job from a pull request's UI, e.g. clicking a job on https://github.com/runs-on/runs-on/pull/245 takes one to a URL like https://github.com/runs-on/runs-on/actions/runs/13674250460/job/38231106711?pr=245, note the `?pr=245`, and thus a "simple" copy-paste of those URLs from the UI will have the query strings.

The previous version of `extractJobID` would extract a job ID like `38231106711?pr=245` (retaining the query string) which didn't work with the rest of the code. This new version uses `net/url` to ensure the code is working with the URL's path alone, ignoring any extraneous data like `?queries` or `#fragments`.