### PR TITLE
roc stack doctor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ go.work.sum
 # binary
 /roc
 /dist
+# doctor files
+/roc-*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Global Flags:
 Example:
 
 ```bash
-roc connect https://github.com/runs-on/runs-on/actions/runs/12415485296/job/34661958899
+AWS_PROFILE=runs-on-admin roc connect https://github.com/runs-on/runs-on/actions/runs/12415485296/job/34661958899
 ```
 
 ## `roc logs`
@@ -70,7 +70,51 @@ Global Flags:
 Example:
 
 ```bash
-roc logs https://github.com/runs-on/runs-on/actions/runs/12415485296/job/34661958899 --watch
+AWS_PROFILE=runs-on-admin roc logs https://github.com/runs-on/runs-on/actions/runs/12415485296/job/34661958899 --watch
+```
+
+## `roc stack doctor`
+
+Diagnose RunsOn stack health and export troubleshooting information.
+
+This command performs comprehensive health checks on your RunsOn CloudFormation stack:
+- Verifies CloudFormation stack status
+- Checks AppRunner service health and version
+- Tests endpoint accessibility  
+- Validates service configuration
+- Fetches application logs
+
+Results are exported as a timestamped ZIP file containing checks.json and logs.
+
+```
+Usage:
+  roc stack doctor [flags]
+
+Flags:
+  -h, --help           help for doctor
+      --since string   Fetch logs since duration (e.g. 30m, 2h, 24h) (default "24h")
+
+Global Flags:
+      --stack string   CloudFormation stack name (default "runs-on")
+```
+
+Example:
+
+```bash
+AWS_PROFILE=runs-on-admin roc stack doctor --since 2h
+```
+
+Output:
+
+```
+Checking CloudFormation stack health (https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?stackId=runs-on-test)... ✅ (status: UPDATE_COMPLETE)
+Checking AppRunner service (https://console.aws.amazon.com/apprunner/home?region=us-east-1#/services/RunsOnService-4rHCauYu4m23)... ✅ (version: v2.8.4)
+Checking AppRunner service endpoint (https://wxrwksit5a.us-east-1.awsapprunner.com)... ✅
+Checking for 'Congrats' response... ✅
+Fetching AppRunner application logs (since 24h0m0s)... ✅ (5419 lines)
+Fetching AppRunner service logs (since 14 days)... ✅ (13 lines)
+
+Full results exported to: /Users/crohr/dev/runs-on/cli/roc-doctor-2025-06-20-12-40-29.zip
 ```
 
 ## Contributing
@@ -78,7 +122,6 @@ roc logs https://github.com/runs-on/runs-on/actions/runs/12415485296/job/3466195
 Contributions are welcome! Ideas of future improvements:
 
 * Make the CloudFormation stack create an IAM role for the CLI to use, so that the CLI automatically assumes it when launched with an admin role?
-* `roc stack doctor` - check RunsOn stack and make sure everything is healthy (AppRunner endpoint health check, GitHub App webhook deliveries, etc.).
 * `roc stack pause|resume` - set RunsOn in maintenance mode (queue incoming jobs, but don't start them), to perform an upgrade.
 * `roc stack upgrade` - upgrade RunsOn stack to the latest version.
 * `roc stack logs` - fetch RunsOn server logs.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.4
 require (
 	github.com/aws/aws-sdk-go-v2 v1.32.8
 	github.com/aws/aws-sdk-go-v2/config v1.28.10
+	github.com/aws/aws-sdk-go-v2/service/apprunner v1.32.3
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.4
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.72.2

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvK
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.27 h1:AmB5QxnD+fBFrg9LcqzkgF/CaYvMyU/BTlejG4t1S7Q=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.27/go.mod h1:Sai7P3xTiyv9ZUYO3IFxMnmiIP759/67iQbU4kdmkyU=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.32.3 h1:wkQpocpYy3/SqFf8iUO1uB5ICK06sm6ajevvft7ijoQ=
+github.com/aws/aws-sdk-go-v2/service/apprunner v1.32.3/go.mod h1:lOQv8hfiAZCHdi+wNKBKdSqf1yCKzWiOEQNVKoK/Jko=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.4 h1:uH6So7Ee+2JQf+TKbfifXKUDNN0JfaJ6CgJ6Bh/u1sc=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.56.4/go.mod h1:GdDLBO8SzD4wvQ6fhqU1QCmvG1waj1MPHL4cBtuSgdQ=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.45.3 h1:va7zt8/kkg5zR0TX2r7wCXssdZ4+blRxbsA6IS9XXYI=

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,508 @@
+package cli
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apprunner"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/spf13/cobra"
+)
+
+type DoctorCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Result string `json:"result"`
+	Error  string `json:"error,omitempty"`
+}
+
+type DoctorResult struct {
+	Timestamp time.Time     `json:"timestamp"`
+	StackName string        `json:"stack_name"`
+	Checks    []DoctorCheck `json:"checks"`
+}
+
+type StackDoctor struct {
+	cfg        aws.Config
+	cfn        *cloudformation.Client
+	apprunner  *apprunner.Client
+	cwl        *cloudwatchlogs.Client
+	stackName  string
+	httpClient *http.Client
+	result     *DoctorResult
+	outputs    map[string]string // Cache stack outputs
+}
+
+func NewStackDoctor(config *RunsOnConfig) *StackDoctor {
+	return &StackDoctor{
+		cfg:       config.AWSConfig,
+		cfn:       cloudformation.NewFromConfig(config.AWSConfig),
+		apprunner: apprunner.NewFromConfig(config.AWSConfig),
+		cwl:       cloudwatchlogs.NewFromConfig(config.AWSConfig),
+		stackName: config.StackName,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		result: &DoctorResult{
+			Timestamp: time.Now(),
+			StackName: config.StackName,
+			Checks:    []DoctorCheck{},
+		},
+	}
+}
+
+func (d *StackDoctor) addCheck(name, status, result string, err error) {
+	check := DoctorCheck{
+		Name:   name,
+		Status: status,
+		Result: result,
+	}
+	if err != nil {
+		check.Error = err.Error()
+	}
+	d.result.Checks = append(d.result.Checks, check)
+}
+
+func (d *StackDoctor) printCheckResult(message, status, details string) {
+	if details != "" {
+		fmt.Printf(" %s (%s)\n", status, details)
+	} else {
+		fmt.Printf(" %s\n", status)
+	}
+}
+
+func (d *StackDoctor) failCheck(name, message string, err error) error {
+	d.addCheck(name, "❌", message, err)
+	d.printCheckResult("", "❌", "")
+	return err
+}
+
+func (d *StackDoctor) loadStackOutputs(ctx context.Context) error {
+	if d.outputs != nil {
+		return nil // Already loaded
+	}
+
+	out, err := d.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: &d.stackName,
+	})
+	if err != nil {
+		return err
+	}
+	if len(out.Stacks) == 0 {
+		return fmt.Errorf("stack %s not found", d.stackName)
+	}
+
+	d.outputs = make(map[string]string)
+	for _, output := range out.Stacks[0].Outputs {
+		d.outputs[*output.OutputKey] = *output.OutputValue
+	}
+	return nil
+}
+
+func (d *StackDoctor) checkStackHealth(ctx context.Context) error {
+	fmt.Print("Checking CloudFormation stack health...")
+
+	err := d.loadStackOutputs(ctx)
+	if err != nil {
+		return d.failCheck("CloudFormation stack health", "Failed to describe stack", err)
+	}
+
+	// Get stack status from the same API call
+	out, err := d.cfn.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: &d.stackName,
+	})
+	if err != nil {
+		return d.failCheck("CloudFormation stack health", "Failed to describe stack", err)
+	}
+
+	stack := out.Stacks[0]
+	status := string(stack.StackStatus)
+
+	if strings.Contains(status, "COMPLETE") && !strings.Contains(status, "ROLLBACK") {
+		d.addCheck("CloudFormation stack health", "✅", fmt.Sprintf("Status: %s", status), nil)
+		d.printCheckResult("", "✅", fmt.Sprintf("status: %s", status))
+		return nil
+	} else {
+		d.addCheck("CloudFormation stack health", "❌", fmt.Sprintf("Status: %s", status), nil)
+		d.printCheckResult("", "❌", fmt.Sprintf("status: %s", status))
+		return fmt.Errorf("stack is in unhealthy state: %s", status)
+	}
+}
+
+func (d *StackDoctor) checkAppRunnerService(ctx context.Context) error {
+	fmt.Print("Checking AppRunner service...")
+
+	if err := d.loadStackOutputs(ctx); err != nil {
+		return d.failCheck("AppRunner service running", "Failed to get stack outputs", err)
+	}
+
+	serviceArn, ok := d.outputs["RunsOnServiceArn"]
+	if !ok {
+		err := fmt.Errorf("RunsOnServiceArn not found in stack outputs")
+		return d.failCheck("AppRunner service running", "Service ARN not found", err)
+	}
+
+	expectedTag := d.outputs["RunsOnAppTag"]
+
+	out, err := d.apprunner.DescribeService(ctx, &apprunner.DescribeServiceInput{
+		ServiceArn: &serviceArn,
+	})
+	if err != nil {
+		return d.failCheck("AppRunner service running", "Failed to describe service", err)
+	}
+
+	service := out.Service
+	status := string(service.Status)
+
+	if status == "RUNNING" {
+		// Extract image tag from the service configuration
+		imageUri := *service.SourceConfiguration.ImageRepository.ImageIdentifier
+		parts := strings.Split(imageUri, ":")
+		var actualTag string
+		if len(parts) > 1 {
+			actualTag = parts[len(parts)-1]
+		}
+
+		if actualTag == expectedTag {
+			d.addCheck("AppRunner service running", "✅", fmt.Sprintf("Version: %s", actualTag), nil)
+			d.printCheckResult("", "✅", fmt.Sprintf("version: %s", actualTag))
+		} else {
+			d.addCheck("AppRunner service running", "⚠️", fmt.Sprintf("Version mismatch - running: %s, expected: %s", actualTag, expectedTag), nil)
+			d.printCheckResult("", "⚠️", fmt.Sprintf("version mismatch - running: %s, expected: %s", actualTag, expectedTag))
+		}
+		return nil
+	} else {
+		d.addCheck("AppRunner service running", "❌", fmt.Sprintf("Status: %s", status), nil)
+		d.printCheckResult("", "❌", fmt.Sprintf("status: %s", status))
+		return fmt.Errorf("service is not running: %s", status)
+	}
+}
+
+func (d *StackDoctor) checkEndpointAccessibility(ctx context.Context) error {
+	if err := d.loadStackOutputs(ctx); err != nil {
+		fmt.Print("Checking AppRunner service endpoint...")
+		return d.failCheck("AppRunner service endpoint accessible", "Failed to get stack outputs", err)
+	}
+
+	entryPoint, ok := d.outputs["RunsOnEntryPoint"]
+	if !ok {
+		fmt.Print("Checking AppRunner service endpoint...")
+		err := fmt.Errorf("RunsOnEntryPoint not found in stack outputs")
+		return d.failCheck("AppRunner service endpoint accessible", "Entry point not found", err)
+	}
+
+	// Ensure https:// prefix
+	if !strings.HasPrefix(entryPoint, "http://") && !strings.HasPrefix(entryPoint, "https://") {
+		entryPoint = "https://" + entryPoint
+	}
+
+	fmt.Printf("Checking AppRunner service endpoint (%s)...", entryPoint)
+
+	// Check if endpoint is accessible
+	resp, err := d.httpClient.Get(entryPoint)
+	if err != nil {
+		d.addCheck("AppRunner service endpoint accessible", "❌", fmt.Sprintf("Failed to connect to %s", entryPoint), err)
+		d.printCheckResult("", "❌", "")
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		d.addCheck("AppRunner service endpoint accessible", "✅", entryPoint, nil)
+		d.printCheckResult("", "✅", "")
+	} else {
+		d.addCheck("AppRunner service endpoint accessible", "❌", fmt.Sprintf("HTTP %d from %s", resp.StatusCode, entryPoint), nil)
+		d.printCheckResult("", "❌", fmt.Sprintf("HTTP %d", resp.StatusCode))
+		return fmt.Errorf("endpoint returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (d *StackDoctor) checkCongratsResponse(ctx context.Context) error {
+	fmt.Print("Checking for 'Congrats' response...")
+
+	if err := d.loadStackOutputs(ctx); err != nil {
+		return d.failCheck("AppRunner service returns 'Congrats'", "Failed to get stack outputs", err)
+	}
+
+	entryPoint, ok := d.outputs["RunsOnEntryPoint"]
+	if !ok {
+		err := fmt.Errorf("RunsOnEntryPoint not found in stack outputs")
+		return d.failCheck("AppRunner service returns 'Congrats'", "Entry point not found", err)
+	}
+
+	// Ensure https:// prefix
+	if !strings.HasPrefix(entryPoint, "http://") && !strings.HasPrefix(entryPoint, "https://") {
+		entryPoint = "https://" + entryPoint
+	}
+
+	resp, err := d.httpClient.Get(entryPoint)
+	if err != nil {
+		return d.failCheck("AppRunner service returns 'Congrats'", "Failed to connect", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return d.failCheck("AppRunner service returns 'Congrats'", "Failed to read response", err)
+	}
+
+	bodyStr := string(body)
+	if strings.Contains(bodyStr, "Congrats") {
+		d.addCheck("AppRunner service returns 'Congrats'", "✅", "Response contains 'Congrats'", nil)
+		d.printCheckResult("", "✅", "")
+		return nil
+	} else {
+		d.addCheck("AppRunner service returns 'Congrats'", "❌", "Response does not contain 'Congrats'", nil)
+		d.printCheckResult("", "❌", "AppRunner service not configured yet")
+		return fmt.Errorf("response does not contain 'Congrats'")
+	}
+}
+
+func (d *StackDoctor) fetchLogs(ctx context.Context, since time.Duration) (int, error) {
+	fmt.Print("Fetching AppRunner logs...")
+
+	if err := d.loadStackOutputs(ctx); err != nil {
+		return 0, d.failCheck("Logs fetched", "Failed to get stack outputs", err)
+	}
+
+	serviceArn, ok := d.outputs["RunsOnServiceArn"]
+	if !ok {
+		err := fmt.Errorf("RunsOnServiceArn not found in stack outputs")
+		return 0, d.failCheck("Logs fetched", "Service ARN not found", err)
+	}
+
+	// Convert AppRunner ARN to CloudWatch log group ARN
+	logGroupArn := getLogGroupArn(serviceArn)
+
+	// Create logs directory
+	err := os.MkdirAll("logs", 0755)
+	if err != nil {
+		return 0, d.failCheck("Logs fetched", "Failed to create logs directory", err)
+	}
+
+	startTime := time.Now().Add(-since)
+
+	input := &cloudwatchlogs.FilterLogEventsInput{
+		LogGroupIdentifier: &logGroupArn,
+		StartTime:          aws.Int64(startTime.UnixMilli()),
+	}
+
+	var totalLines int
+	logFile, err := os.Create("logs/application.log")
+	if err != nil {
+		return 0, d.failCheck("Logs fetched", "Failed to create log file", err)
+	}
+	defer logFile.Close()
+
+	paginator := cloudwatchlogs.NewFilterLogEventsPaginator(d.cwl, input)
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			return 0, d.failCheck("Logs fetched", "Failed to fetch logs", err)
+		}
+
+		for _, event := range output.Events {
+			timestamp := time.UnixMilli(*event.Timestamp).Format("2006-01-02T15:04:05.000Z")
+			line := fmt.Sprintf("%s [%s] %s\n", timestamp, *event.LogStreamName, *event.Message)
+			logFile.WriteString(line)
+			totalLines++
+		}
+	}
+
+	d.addCheck("Logs fetched", "✅", fmt.Sprintf("Fetched %d lines since %s", totalLines, since), nil)
+	d.printCheckResult("", "✅", fmt.Sprintf("%d lines since %s", totalLines, since))
+	return totalLines, nil
+}
+
+func (d *StackDoctor) saveResults() error {
+	// Save checks.json
+	checksData, err := json.MarshalIndent(d.result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal results: %w", err)
+	}
+
+	err = os.WriteFile("checks.json", checksData, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write checks.json: %w", err)
+	}
+
+	return nil
+}
+
+func (d *StackDoctor) createZipFile() (string, error) {
+	timestamp := time.Now().Format("2006-01-02-15-04-05")
+	zipFileName := fmt.Sprintf("roc-doctor-%s.zip", timestamp)
+
+	zipFile, err := os.Create(zipFileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to create zip file: %w", err)
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	// Add checks.json
+	err = addFileToZip(zipWriter, "checks.json")
+	if err != nil {
+		return "", fmt.Errorf("failed to add checks.json to zip: %w", err)
+	}
+
+	// Add logs directory
+	err = addDirectoryToZip(zipWriter, "logs")
+	if err != nil {
+		return "", fmt.Errorf("failed to add logs directory to zip: %w", err)
+	}
+
+	return zipFileName, nil
+}
+
+func addFileToZip(zipWriter *zip.Writer, filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+	header.Name = filename
+
+	writer, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(writer, file)
+	return err
+}
+
+func addDirectoryToZip(zipWriter *zip.Writer, dirname string) error {
+	return filepath.Walk(dirname, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		header, err := zip.FileInfoHeader(info)
+		if err != nil {
+			return err
+		}
+		header.Name = path
+
+		writer, err := zipWriter.CreateHeader(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(writer, file)
+		return err
+	})
+}
+
+func (d *StackDoctor) cleanup() {
+	os.Remove("checks.json")
+	os.RemoveAll("logs")
+}
+
+func (d *StackDoctor) Run(ctx context.Context, since time.Duration) error {
+	defer d.cleanup()
+
+	// Run all checks
+	d.checkStackHealth(ctx)
+	d.checkAppRunnerService(ctx)
+	d.checkEndpointAccessibility(ctx)
+	d.checkCongratsResponse(ctx)
+	d.fetchLogs(ctx, since)
+
+	// Save results
+	err := d.saveResults()
+	if err != nil {
+		return fmt.Errorf("failed to save results: %w", err)
+	}
+
+	// Create zip file
+	zipFileName, err := d.createZipFile()
+	if err != nil {
+		return fmt.Errorf("failed to create zip file: %w", err)
+	}
+
+	// Get absolute path for output
+	absPath, err := filepath.Abs(zipFileName)
+	if err != nil {
+		absPath = zipFileName
+	}
+
+	fmt.Printf("\nFull results exported to: %s\n", absPath)
+
+	return nil
+}
+
+func NewDoctorCmd() *cobra.Command {
+	var since string
+
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Diagnose RunsOn stack health and export troubleshooting information",
+		Long: `Diagnose RunsOn stack health and export troubleshooting information.
+
+This command performs comprehensive health checks on your RunsOn CloudFormation stack:
+- Verifies CloudFormation stack status
+- Checks AppRunner service health and version
+- Tests endpoint accessibility  
+- Validates service configuration
+- Fetches application logs
+
+Results are exported as a timestamped ZIP file containing checks.json and logs.
+
+The stack name can be overridden using the RUNS_ON_STACK_NAME environment variable.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			config, err := getStackOutputs(cmd)
+			if err != nil {
+				return err
+			}
+
+			// Parse since duration
+			duration, err := time.ParseDuration(since)
+			if err != nil {
+				return fmt.Errorf("invalid --since value: %w", err)
+			}
+
+			doctor := NewStackDoctor(config)
+			return doctor.Run(cmd.Context(), duration)
+		},
+	}
+
+	cmd.Flags().StringVar(&since, "since", "24h", "Fetch logs since duration (e.g. 30m, 2h, 24h)")
+
+	return cmd
+}

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -318,7 +318,7 @@ func (f *LogFetcher) FetchLogs(ctx context.Context, watch bool, watchInterval ti
 
 	collector.wg.Add(1)
 	go func() {
-		logGroupArn := getLogGroupArn(f.outputs.AppRunnerServiceArn)
+		logGroupArn := getLogGroupArn(f.outputs.AppRunnerServiceArn, "application")
 		if err := f.streamLogs(ctx, watch, watchInterval, "application", func(input *cloudwatchlogs.FilterLogEventsInput) error {
 			input.LogGroupIdentifier = &logGroupArn
 			filterPatterns := []string{}
@@ -376,8 +376,8 @@ func (f *LogFetcher) FetchLogs(ctx context.Context, watch bool, watchInterval ti
 	}
 }
 
-func getLogGroupArn(arn string) string {
-	return fmt.Sprintf("%s/application", strings.Replace(strings.Replace(arn, "apprunner", "logs", 1), ":service", ":log-group:/aws/apprunner", 1))
+func getLogGroupArn(arn string, name string) string {
+	return fmt.Sprintf("%s/%s", strings.Replace(strings.Replace(arn, "apprunner", "logs", 1), ":service", ":log-group:/aws/apprunner", 1), name)
 }
 
 func extractJobID(input string) string {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -68,11 +68,12 @@ func NewRootCmd() *cobra.Command {
 		defaultStack = "runs-on"
 	}
 
-	cmd.PersistentFlags().String("stack", defaultStack, "CloudFormation stack name")
+	cmd.PersistentFlags().String("stack", defaultStack, "CloudFormation stack name (can also be set via RUNS_ON_STACK_NAME env var)")
 
 	cmd.AddCommand(
 		NewLogsCmd(),
 		NewConnectCmd(),
+		NewStackCmd(),
 	)
 
 	return cmd

--- a/internal/cli/stack.go
+++ b/internal/cli/stack.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func NewStackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stack",
+		Short: "RunsOn stack management commands",
+		Long: `Commands for managing and troubleshooting your RunsOn CloudFormation stack.
+
+These commands operate on your deployed RunsOn CloudFormation stack to help you
+manage, monitor, and troubleshoot your RunsOn infrastructure.
+
+The stack name can be specified using the --stack flag or by setting the 
+RUNS_ON_STACK_NAME environment variable (defaults to "runs-on").`,
+	}
+
+	cmd.AddCommand(
+		NewDoctorCmd(),
+	)
+
+	return cmd
+}


### PR DESCRIPTION
Fixes #7. Mostly coded by Sonnet using the issue description, but it appears to work fine on first shot:

```bash
❯ AWS_PROFILE=runs-on-admin go run . stack doctor --stack runs-on-stage --since 1h
Checking CloudFormation stack health... ✅ (status: UPDATE_COMPLETE)
Checking AppRunner service... ⚠️ (version mismatch - running: v2.8.3, expected: v2.8.4)
Checking AppRunner service endpoint (https://zurq6pyfus.us-east-1.awsapprunner.com)... ✅
Checking for 'Congrats' response... ✅
Fetching AppRunner application logs (since 1h0m0s)... ✅ (926 lines)
Fetching AppRunner service logs (since 14 days)... ✅ (14 lines)

Full results exported to: /Users/crohr/dev/runs-on/cli/roc-doctor-2025-06-13-12-41-01.zip
```


```bash
❯ unzip -l /Users/crohr/dev/runs-on/cli/roc-doctor-2025-06-13-12-41-01.zip
Archive:  /Users/crohr/dev/runs-on/cli/roc-doctor-2025-06-13-12-41-01.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      879  06-13-2025 12:41   checks.json
   309042  06-13-2025 12:41   logs/application.log
     1818  06-13-2025 12:41   logs/service.log
---------                     -------
   311739                     3 files
```