### PR TITLE
fix(interrupt): correct malformed FIS role trust policy

### DIFF
--- a/internal/cli/interrupt.go
+++ b/internal/cli/interrupt.go
@@ -24,9 +24,7 @@ const (
 			{
 				"Effect": "Allow",
 				"Principal": {
-					"Service": [
-					  ["fis.amazonaws.com"]
-					]
+					"Service": "fis.amazonaws.com"
 				},
 				"Action": "sts:AssumeRole"
 			}

--- a/internal/cli/interrupt_test.go
+++ b/internal/cli/interrupt_test.go
@@ -1,0 +1,47 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTrustPolicyIsValidForIAM guards against the regression where the FIS
+// trust policy nested the service principal as [["fis.amazonaws.com"]], which
+// IAM rejects with MalformedPolicyDocument. The Principal.Service must be a
+// plain string (or flat array) of service principals.
+func TestTrustPolicyIsValidForIAM(t *testing.T) {
+	var doc struct {
+		Version   string `json:"Version"`
+		Statement []struct {
+			Effect    string `json:"Effect"`
+			Action    string `json:"Action"`
+			Principal struct {
+				Service json.RawMessage `json:"Service"`
+			} `json:"Principal"`
+		} `json:"Statement"`
+	}
+
+	if err := json.Unmarshal([]byte(trustPolicy), &doc); err != nil {
+		t.Fatalf("trustPolicy is not valid JSON: %v", err)
+	}
+	if len(doc.Statement) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(doc.Statement))
+	}
+
+	svc := doc.Statement[0].Principal.Service
+	// Must decode either as a string or a flat []string — never a nested array.
+	var asString string
+	if err := json.Unmarshal(svc, &asString); err == nil {
+		if asString != "fis.amazonaws.com" {
+			t.Fatalf("unexpected service principal: %q", asString)
+		}
+		return
+	}
+	var asSlice []string
+	if err := json.Unmarshal(svc, &asSlice); err != nil {
+		t.Fatalf("Principal.Service must be a string or flat []string, got: %s", string(svc))
+	}
+	if len(asSlice) != 1 || asSlice[0] != "fis.amazonaws.com" {
+		t.Fatalf("unexpected service principals: %v", asSlice)
+	}
+}


### PR DESCRIPTION
## Problem

`roc interrupt` fails whenever the `aws-fis-itn` FIS role doesn't already exist. The trust policy literal nests the service principal as a sub-array:

```json
"Principal": {
    "Service": [
      ["fis.amazonaws.com"]
    ]
}
```

IAM rejects this on `CreateRole`:

```
MalformedPolicyDocument: Syntax error at position (8,9)
```

(Position `(8,9)` is exactly the inner `[`.) All pre-flight checks pass — it only fails at role creation — so the command is unusable on first run in any account.

Reported in #22.

## Fix

Flatten `Principal.Service` to a plain string:

```json
"Principal": {
    "Service": "fis.amazonaws.com"
}
```

Added `TestTrustPolicyIsValidForIAM` to guard against the nested-array regression (asserts `Principal.Service` decodes as a string or flat `[]string`).

## Testing

- `go build ./...` — OK
- `go test ./internal/cli/ -run TestTrustPolicyIsValidForIAM` — PASS
- Verified end-to-end against a real RunsOn Flex stack: with the corrected policy, `roc interrupt` creates the role and runs the FIS spot-interruption experiment successfully.