### PR TITLE
Add check for kms permissions for EBS Encryption to doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ This command performs comprehensive health checks on your RunsOn stack:
 - Checks ECS service health
 - Tests endpoint accessibility for Flex stacks
 - Validates service readiness for Flex stacks
+- Validates Flex EBS encryption KMS permissions on the flex role
 - Fetches application logs
 
 Results are exported as a timestamped ZIP file containing checks.json and logs.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.80.0
 	github.com/aws/aws-sdk-go-v2/service/fis v1.37.22
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
+	github.com/aws/aws-sdk-go-v2/service/kms v1.49.3
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.7

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23 h1:3Eo
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.23/go.mod h1:3oh+5xGSd1iuxonVb3Qbm+WJYlbhczT9kbzr6doJLzY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23 h1:pbrxO/kuIwgEsOPLkaHu0O+m4fNgLU8B3vxQ+72jTPw=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.23/go.mod h1:/CMNUqoj46HpS3MNRDEDIwcgEnrtZlKRaHNaHxIFpNA=
+github.com/aws/aws-sdk-go-v2/service/kms v1.49.3 h1:FtjNR2BaMf/Wu3Um8RNSAfi9An5bEYxJU6f4rLOqSLU=
+github.com/aws/aws-sdk-go-v2/service/kms v1.49.3/go.mod h1:HO31s0qt0lso/ADvZQyzKs8js/ku0fMHsfyXW8OPVYc=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1 h1:odCeJgHXfQoXEWQUIzPkKvsJTWcLMsaOWowNpovPFFw=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.90.1/go.mod h1:NbtJVztitG7JkuoI4GSrDUlsB32zeXqKBvXj6bUxcMo=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.12 h1:kOX5fCUb0BSMNHbRm7icw/dEyTjiYCLczIYglbYFJnI=

--- a/internal/cli/discovery.go
+++ b/internal/cli/discovery.go
@@ -29,6 +29,7 @@ type stackConfigSecretValue struct {
 	IngressURL                         string `json:"IngressURL"`
 	ServiceLogGroupName                string `json:"ServiceLogGroupName"`
 	EC2InstanceLogGroupArn             string `json:"Ec2InstanceLogGroupArn"`
+	EbsEncryptionKey                   string `json:"EbsEncryptionKey"`
 }
 
 type fleetConfigSecretValue struct {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -414,6 +414,7 @@ func (d *StackDoctor) Run(ctx context.Context, since time.Duration) error {
 	// Run all checks, but continue on failures so doctor can export partial results.
 	_ = d.checkService(ctx)
 	d.checkHTTPHealth()
+	_ = d.checkEBSEncryptionKMS(ctx)
 	_, _ = d.fetchLogs(ctx, since)
 
 	// Save results
@@ -451,6 +452,7 @@ This command performs comprehensive health checks on your RunsOn stack:
 - Checks ECS service health
 - Tests endpoint accessibility for Flex stacks
 - Validates service readiness for Flex stacks
+- Validates Flex EBS encryption KMS permissions on the flex role
 - Fetches application logs
 
 Results are exported as a timestamped ZIP file containing checks.json and logs.

--- a/internal/cli/doctor_ebs.go
+++ b/internal/cli/doctor_ebs.go
@@ -1,0 +1,441 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+)
+
+const awsManagedEBSAlias = "alias/aws/ebs"
+
+var requiredFlexRoleKMSActions = []string{
+	"kms:Decrypt",
+	"kms:DescribeKey",
+	"kms:Encrypt",
+	"kms:GenerateDataKey",
+	"kms:GenerateDataKeyWithoutPlaintext",
+	"kms:ReEncryptFrom",
+	"kms:ReEncryptTo",
+}
+
+type doctorEC2API interface {
+	GetEbsEncryptionByDefault(ctx context.Context, params *ec2.GetEbsEncryptionByDefaultInput, optFns ...func(*ec2.Options)) (*ec2.GetEbsEncryptionByDefaultOutput, error)
+	GetEbsDefaultKmsKeyId(ctx context.Context, params *ec2.GetEbsDefaultKmsKeyIdInput, optFns ...func(*ec2.Options)) (*ec2.GetEbsDefaultKmsKeyIdOutput, error)
+}
+
+type doctorKMSAPI interface {
+	DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+}
+
+type doctorIAMAPI interface {
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	ListRolePolicies(ctx context.Context, params *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+	GetRolePolicy(ctx context.Context, params *iam.GetRolePolicyInput, optFns ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error)
+	ListAttachedRolePolicies(ctx context.Context, params *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	GetPolicy(ctx context.Context, params *iam.GetPolicyInput, optFns ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	GetPolicyVersion(ctx context.Context, params *iam.GetPolicyVersionInput, optFns ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
+}
+
+type ebsEncryptionKeyInfo struct {
+	DisplayName string
+	KeyARN      string
+	KeyID       string
+	Source      string
+}
+
+type iamPolicyDocument struct {
+	Statement []iamPolicyStatement `json:"Statement"`
+}
+
+type iamPolicyStatement struct {
+	Effect    string                            `json:"Effect"`
+	Action    any                               `json:"Action"`
+	Resource  any                               `json:"Resource"`
+	Condition map[string]map[string]interface{} `json:"Condition"`
+}
+
+func flexRoleName(stackName string) string {
+	return fmt.Sprintf("%s-flex-role", strings.TrimSpace(stackName))
+}
+
+func loadFlexStackConfigSecret(ctx context.Context, client stackConfigSecretAPI, stackName string) (stackConfigSecretValue, error) {
+	if client == nil {
+		return stackConfigSecretValue{}, fmt.Errorf("stack config client is required")
+	}
+	stackName = strings.TrimSpace(stackName)
+	if stackName == "" {
+		return stackConfigSecretValue{}, fmt.Errorf("stack name is required")
+	}
+
+	output, err := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(stackConfigSecretID(stackName)),
+	})
+	if err != nil {
+		return stackConfigSecretValue{}, fmt.Errorf("load stack config secret: %w", err)
+	}
+	if output.SecretString == nil || strings.TrimSpace(*output.SecretString) == "" {
+		return stackConfigSecretValue{}, fmt.Errorf("stack config secret is empty")
+	}
+
+	var secret stackConfigSecretValue
+	if err := json.Unmarshal([]byte(*output.SecretString), &secret); err != nil {
+		return stackConfigSecretValue{}, fmt.Errorf("parse stack config: %w", err)
+	}
+	return secret, nil
+}
+
+func resolveEBSEncryptionKey(ctx context.Context, ec2Client doctorEC2API, kmsClient doctorKMSAPI, configuredKey string) (*ebsEncryptionKeyInfo, error) {
+	configuredKey = strings.TrimSpace(configuredKey)
+	if configuredKey != "" {
+		info, err := describeKMSKey(ctx, kmsClient, configuredKey)
+		if err != nil {
+			return nil, err
+		}
+		info.Source = "stack-config EbsEncryptionKey"
+		return info, nil
+	}
+
+	if ec2Client == nil {
+		return nil, fmt.Errorf("ec2 client is required")
+	}
+	if kmsClient == nil {
+		return nil, fmt.Errorf("kms client is required")
+	}
+
+	enabledOutput, err := ec2Client.GetEbsEncryptionByDefault(ctx, &ec2.GetEbsEncryptionByDefaultInput{})
+	if err != nil {
+		return nil, fmt.Errorf("get EBS encryption by default: %w", err)
+	}
+	if !aws.ToBool(enabledOutput.EbsEncryptionByDefault) {
+		return nil, fmt.Errorf("EbsEncryptionKey is not set in stack-config and account EBS default encryption is disabled")
+	}
+
+	defaultKeyOutput, err := ec2Client.GetEbsDefaultKmsKeyId(ctx, &ec2.GetEbsDefaultKmsKeyIdInput{})
+	if err != nil {
+		return nil, fmt.Errorf("get EBS default KMS key: %w", err)
+	}
+	defaultKeyID := strings.TrimSpace(aws.ToString(defaultKeyOutput.KmsKeyId))
+	if defaultKeyID == "" {
+		return nil, fmt.Errorf("account EBS default encryption is enabled but no default KMS key was returned")
+	}
+
+	info, err := describeKMSKey(ctx, kmsClient, defaultKeyID)
+	if err != nil {
+		return nil, err
+	}
+	info.Source = "account EBS default encryption"
+	return info, nil
+}
+
+func describeKMSKey(ctx context.Context, kmsClient doctorKMSAPI, keyRef string) (*ebsEncryptionKeyInfo, error) {
+	if kmsClient == nil {
+		return nil, fmt.Errorf("kms client is required")
+	}
+	keyRef = strings.TrimSpace(keyRef)
+	if keyRef == "" {
+		return nil, fmt.Errorf("kms key reference is required")
+	}
+
+	output, err := kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(keyRef),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("describe kms key %q: %w", keyRef, err)
+	}
+	if output.KeyMetadata == nil {
+		return nil, fmt.Errorf("describe kms key %q returned no metadata", keyRef)
+	}
+
+	info := &ebsEncryptionKeyInfo{
+		DisplayName: aws.ToString(output.KeyMetadata.Arn),
+		KeyARN:      aws.ToString(output.KeyMetadata.Arn),
+		KeyID:       aws.ToString(output.KeyMetadata.KeyId),
+	}
+	if info.KeyARN == "" || info.KeyID == "" {
+		return nil, fmt.Errorf("describe kms key %q returned incomplete metadata", keyRef)
+	}
+
+	managedOutput, err := kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(awsManagedEBSAlias),
+	})
+	if err == nil && managedOutput.KeyMetadata != nil {
+		if aws.ToString(managedOutput.KeyMetadata.KeyId) == info.KeyID {
+			info.DisplayName = awsManagedEBSAlias
+		}
+	}
+
+	return info, nil
+}
+
+func collectRolePolicyDocuments(ctx context.Context, iamClient doctorIAMAPI, roleName string) ([]string, error) {
+	if iamClient == nil {
+		return nil, fmt.Errorf("iam client is required")
+	}
+	roleName = strings.TrimSpace(roleName)
+	if roleName == "" {
+		return nil, fmt.Errorf("role name is required")
+	}
+
+	if _, err := iamClient.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)}); err != nil {
+		return nil, fmt.Errorf("get role %q: %w", roleName, err)
+	}
+
+	var documents []string
+
+	inlineOutput, err := iamClient.ListRolePolicies(ctx, &iam.ListRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list inline policies for role %q: %w", roleName, err)
+	}
+	for _, policyName := range inlineOutput.PolicyNames {
+		policyOutput, err := iamClient.GetRolePolicy(ctx, &iam.GetRolePolicyInput{
+			RoleName:   aws.String(roleName),
+			PolicyName: aws.String(policyName),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get inline policy %q for role %q: %w", policyName, roleName, err)
+		}
+		document, err := decodeIAMPolicyDocument(aws.ToString(policyOutput.PolicyDocument))
+		if err != nil {
+			return nil, fmt.Errorf("decode inline policy %q for role %q: %w", policyName, roleName, err)
+		}
+		documents = append(documents, document)
+	}
+
+	attachedOutput, err := iamClient.ListAttachedRolePolicies(ctx, &iam.ListAttachedRolePoliciesInput{
+		RoleName: aws.String(roleName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list attached policies for role %q: %w", roleName, err)
+	}
+	for _, attachedPolicy := range attachedOutput.AttachedPolicies {
+		policyARN := strings.TrimSpace(aws.ToString(attachedPolicy.PolicyArn))
+		if policyARN == "" {
+			continue
+		}
+		policyOutput, err := iamClient.GetPolicy(ctx, &iam.GetPolicyInput{
+			PolicyArn: aws.String(policyARN),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get policy %q: %w", policyARN, err)
+		}
+		versionID := strings.TrimSpace(aws.ToString(policyOutput.Policy.DefaultVersionId))
+		if versionID == "" {
+			continue
+		}
+		versionOutput, err := iamClient.GetPolicyVersion(ctx, &iam.GetPolicyVersionInput{
+			PolicyArn: aws.String(policyARN),
+			VersionId: aws.String(versionID),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get policy version %q for %q: %w", versionID, policyARN, err)
+		}
+		document, err := decodeIAMPolicyDocument(aws.ToString(versionOutput.PolicyVersion.Document))
+		if err != nil {
+			return nil, fmt.Errorf("decode policy %q: %w", policyARN, err)
+		}
+		documents = append(documents, document)
+	}
+
+	return documents, nil
+}
+
+func decodeIAMPolicyDocument(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("policy document is empty")
+	}
+	decoded, err := url.QueryUnescape(raw)
+	if err != nil {
+		return "", err
+	}
+	return decoded, nil
+}
+
+func missingFlexRoleKMSPermissions(documents []string, keyARN string) ([]string, error) {
+	missing := append([]string{}, requiredFlexRoleKMSActions...)
+	missing = append(missing, "kms:CreateGrant")
+
+	for _, document := range documents {
+		var policy iamPolicyDocument
+		if err := json.Unmarshal([]byte(document), &policy); err != nil {
+			return nil, fmt.Errorf("parse iam policy document: %w", err)
+		}
+		for _, statement := range policy.Statement {
+			if !strings.EqualFold(strings.TrimSpace(statement.Effect), "Allow") {
+				continue
+			}
+			if !iamStatementMatchesKeyResource(statement.Resource, keyARN) {
+				continue
+			}
+
+			actions := normalizeIAMPolicyStrings(statement.Action)
+			for i := len(missing) - 1; i >= 0; i-- {
+				action := missing[i]
+				if action == "kms:CreateGrant" {
+					if iamActionAllowed(actions, action) && iamCreateGrantConditionMatches(statement.Condition) {
+						missing = append(missing[:i], missing[i+1:]...)
+					}
+					continue
+				}
+				if iamActionAllowed(actions, action) {
+					missing = append(missing[:i], missing[i+1:]...)
+				}
+			}
+		}
+	}
+
+	return missing, nil
+}
+
+func normalizeIAMPolicyStrings(value any) []string {
+	switch typed := value.(type) {
+	case string:
+		return []string{strings.TrimSpace(typed)}
+	case []any:
+		var values []string
+		for _, item := range typed {
+			values = append(values, normalizeIAMPolicyStrings(item)...)
+		}
+		return values
+	case []string:
+		var values []string
+		for _, item := range typed {
+			item = strings.TrimSpace(item)
+			if item != "" {
+				values = append(values, item)
+			}
+		}
+		return values
+	default:
+		return nil
+	}
+}
+
+func iamStatementMatchesKeyResource(resourceValue any, keyARN string) bool {
+	for _, resource := range normalizeIAMPolicyStrings(resourceValue) {
+		if iamResourceMatches(resource, keyARN) {
+			return true
+		}
+	}
+	return false
+}
+
+func iamResourceMatches(resource, keyARN string) bool {
+	resource = strings.TrimSpace(resource)
+	keyARN = strings.TrimSpace(keyARN)
+	if resource == "" || keyARN == "" {
+		return false
+	}
+	if resource == "*" {
+		return true
+	}
+	if resource == keyARN {
+		return true
+	}
+	if strings.Contains(resource, "*") {
+		prefix := strings.SplitN(resource, "*", 2)[0]
+		return strings.HasPrefix(keyARN, prefix)
+	}
+	return false
+}
+
+func iamActionAllowed(actions []string, required string) bool {
+	for _, action := range actions {
+		action = strings.TrimSpace(action)
+		if action == "" {
+			continue
+		}
+		if action == "*" || action == "kms:*" {
+			return true
+		}
+		if strings.EqualFold(action, required) {
+			return true
+		}
+		if strings.HasSuffix(action, "*") {
+			prefix := strings.TrimSuffix(action, "*")
+			if strings.HasPrefix(required, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func iamCreateGrantConditionMatches(conditions map[string]map[string]interface{}) bool {
+	if len(conditions) == 0 {
+		return false
+	}
+	boolConditions, ok := conditions["Bool"]
+	if !ok {
+		return false
+	}
+	value, ok := boolConditions["kms:GrantIsForAWSResource"]
+	if !ok {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
+}
+
+func (d *StackDoctor) checkEBSEncryptionKMS(ctx context.Context) error {
+	if strings.EqualFold(strings.TrimSpace(d.config.Product), "fleet") {
+		fmt.Print("Checking EBS encryption KMS permissions...")
+		d.skipCheck("EBS encryption KMS permissions", "Skipped - Fleet stacks do not use the flex role")
+		return nil
+	}
+
+	roleName := flexRoleName(d.config.StackName)
+	fmt.Printf("Checking EBS encryption KMS permissions (%s)...", roleName)
+
+	secretsClient := secretsmanager.NewFromConfig(d.cfg)
+	secret, err := loadFlexStackConfigSecret(ctx, secretsClient, d.config.StackName)
+	if err != nil {
+		return d.failCheck("EBS encryption KMS permissions", "Failed to load stack-config secret", err)
+	}
+
+	ec2Client := ec2.NewFromConfig(d.cfg)
+	kmsClient := kms.NewFromConfig(d.cfg)
+	keyInfo, err := resolveEBSEncryptionKey(ctx, ec2Client, kmsClient, secret.EbsEncryptionKey)
+	if err != nil {
+		return d.failCheck("EBS encryption KMS permissions", "Failed to resolve EBS encryption key", err)
+	}
+
+	iamClient := iam.NewFromConfig(d.cfg)
+	documents, err := collectRolePolicyDocuments(ctx, iamClient, roleName)
+	if err != nil {
+		return d.failCheck("EBS encryption KMS permissions", fmt.Sprintf("Failed to load IAM policies for role %s", roleName), err)
+	}
+
+	missing, err := missingFlexRoleKMSPermissions(documents, keyInfo.KeyARN)
+	if err != nil {
+		return d.failCheck("EBS encryption KMS permissions", "Failed to evaluate IAM policy permissions", err)
+	}
+
+	result := fmt.Sprintf("key: %s (source: %s)", keyInfo.DisplayName, keyInfo.Source)
+	if len(missing) > 0 {
+		message := fmt.Sprintf("%s; missing permissions on %s: %s", result, roleName, strings.Join(missing, ", "))
+		d.addCheck("EBS encryption KMS permissions", "❌", message, nil)
+		d.printCheckResult("❌", message)
+		return fmt.Errorf("flex role is missing KMS permissions: %s", strings.Join(missing, ", "))
+	}
+
+	d.addCheck("EBS encryption KMS permissions", "✅", fmt.Sprintf("%s; role %s has required KMS permissions", result, roleName), nil)
+	d.printCheckResult("✅", fmt.Sprintf("key: %s", keyInfo.DisplayName))
+	return nil
+}

--- a/internal/cli/doctor_ebs_test.go
+++ b/internal/cli/doctor_ebs_test.go
@@ -1,0 +1,349 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+func TestFlexRoleName(t *testing.T) {
+	t.Parallel()
+
+	if got := flexRoleName("runs-on"); got != "runs-on-flex-role" {
+		t.Fatalf("unexpected role name %q", got)
+	}
+}
+
+func TestMissingFlexRoleKMSPermissionsDetectsMissingActions(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	policy := `{
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": [
+				"kms:Decrypt",
+				"kms:DescribeKey",
+				"kms:Encrypt",
+				"kms:GenerateDataKey",
+				"kms:GenerateDataKeyWithoutPlaintext",
+				"kms:ReEncryptFrom",
+				"kms:ReEncryptTo"
+			],
+			"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+		}]
+	}`
+
+	missing, err := missingFlexRoleKMSPermissions([]string{policy}, keyARN)
+	if err != nil {
+		t.Fatalf("missingFlexRoleKMSPermissions returned error: %v", err)
+	}
+	if len(missing) != 1 || missing[0] != "kms:CreateGrant" {
+		t.Fatalf("expected only kms:CreateGrant to be missing, got %v", missing)
+	}
+}
+
+func TestMissingFlexRoleKMSPermissionsAcceptsCompletePolicy(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	policy := `{
+		"Statement": [
+			{
+				"Effect": "Allow",
+				"Action": [
+					"kms:Decrypt",
+					"kms:DescribeKey",
+					"kms:Encrypt",
+					"kms:GenerateDataKey",
+					"kms:GenerateDataKeyWithoutPlaintext",
+					"kms:ReEncryptFrom",
+					"kms:ReEncryptTo"
+				],
+				"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+			},
+			{
+				"Effect": "Allow",
+				"Action": ["kms:CreateGrant"],
+				"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd",
+				"Condition": {
+					"Bool": {
+						"kms:GrantIsForAWSResource": true
+					}
+				}
+			}
+		]
+	}`
+
+	missing, err := missingFlexRoleKMSPermissions([]string{policy}, keyARN)
+	if err != nil {
+		t.Fatalf("missingFlexRoleKMSPermissions returned error: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing permissions, got %v", missing)
+	}
+}
+
+func TestMissingFlexRoleKMSPermissionsMatchesWildcardResource(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	policy := `{
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": "kms:*",
+			"Resource": "arn:aws:kms:us-west-2:411491144243:key/*"
+		}]
+	}`
+
+	missing, err := missingFlexRoleKMSPermissions([]string{policy}, keyARN)
+	if err != nil {
+		t.Fatalf("missingFlexRoleKMSPermissions returned error: %v", err)
+	}
+	if len(missing) != 1 || missing[0] != "kms:CreateGrant" {
+		t.Fatalf("expected kms:CreateGrant to require explicit grant condition, got %v", missing)
+	}
+}
+
+func TestResolveEBSEncryptionKeyUsesConfiguredKey(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/abc-123"
+	kmsClient := &mockDoctorKMSClient{
+		describeKey: func(_ context.Context, input *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+			switch aws.ToString(input.KeyId) {
+			case "configured-key":
+				return &kms.DescribeKeyOutput{
+					KeyMetadata: &kmstypes.KeyMetadata{
+						Arn:   aws.String(keyARN),
+						KeyId: aws.String("abc-123"),
+					},
+				}, nil
+			case awsManagedEBSAlias:
+				return &kms.DescribeKeyOutput{
+					KeyMetadata: &kmstypes.KeyMetadata{
+						KeyId: aws.String("different-key"),
+					},
+				}, nil
+			default:
+				t.Fatalf("unexpected key id %q", aws.ToString(input.KeyId))
+				return nil, nil
+			}
+		},
+	}
+
+	info, err := resolveEBSEncryptionKey(context.Background(), nil, kmsClient, "configured-key")
+	if err != nil {
+		t.Fatalf("resolveEBSEncryptionKey returned error: %v", err)
+	}
+	if info.KeyARN != keyARN {
+		t.Fatalf("unexpected key ARN %q", info.KeyARN)
+	}
+	if info.Source != "stack-config EbsEncryptionKey" {
+		t.Fatalf("unexpected source %q", info.Source)
+	}
+}
+
+func TestResolveEBSEncryptionKeyUsesAccountDefault(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-east-1:123456789012:key/aws-managed"
+	ec2Client := &mockDoctorEC2Client{
+		getEbsEncryptionByDefault: func(context.Context, *ec2.GetEbsEncryptionByDefaultInput, ...func(*ec2.Options)) (*ec2.GetEbsEncryptionByDefaultOutput, error) {
+			return &ec2.GetEbsEncryptionByDefaultOutput{EbsEncryptionByDefault: aws.Bool(true)}, nil
+		},
+		getEbsDefaultKmsKeyId: func(context.Context, *ec2.GetEbsDefaultKmsKeyIdInput, ...func(*ec2.Options)) (*ec2.GetEbsDefaultKmsKeyIdOutput, error) {
+			return &ec2.GetEbsDefaultKmsKeyIdOutput{KmsKeyId: aws.String(awsManagedEBSAlias)}, nil
+		},
+	}
+	kmsClient := &mockDoctorKMSClient{
+		describeKey: func(_ context.Context, input *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+			return &kms.DescribeKeyOutput{
+				KeyMetadata: &kmstypes.KeyMetadata{
+					Arn:   aws.String(keyARN),
+					KeyId: aws.String("aws-managed"),
+				},
+			}, nil
+		},
+	}
+
+	info, err := resolveEBSEncryptionKey(context.Background(), ec2Client, kmsClient, "")
+	if err != nil {
+		t.Fatalf("resolveEBSEncryptionKey returned error: %v", err)
+	}
+	if info.DisplayName != awsManagedEBSAlias {
+		t.Fatalf("expected display name %q, got %q", awsManagedEBSAlias, info.DisplayName)
+	}
+	if info.Source != "account EBS default encryption" {
+		t.Fatalf("unexpected source %q", info.Source)
+	}
+}
+
+func TestStackDoctorSkipsEBSCheckForFleet(t *testing.T) {
+	t.Parallel()
+
+	doctor := NewStackDoctor(&RunsOnConfig{Product: "fleet", StackName: "runs-on"})
+	if err := doctor.checkEBSEncryptionKMS(context.Background()); err != nil {
+		t.Fatalf("checkEBSEncryptionKMS returned error: %v", err)
+	}
+	if len(doctor.result.Checks) != 1 {
+		t.Fatalf("expected one skipped check, got %+v", doctor.result.Checks)
+	}
+	if doctor.result.Checks[0].Status != "⏭️" {
+		t.Fatalf("expected skipped status, got %+v", doctor.result.Checks[0])
+	}
+}
+
+type mockDoctorEC2Client struct {
+	getEbsEncryptionByDefault func(context.Context, *ec2.GetEbsEncryptionByDefaultInput, ...func(*ec2.Options)) (*ec2.GetEbsEncryptionByDefaultOutput, error)
+	getEbsDefaultKmsKeyId     func(context.Context, *ec2.GetEbsDefaultKmsKeyIdInput, ...func(*ec2.Options)) (*ec2.GetEbsDefaultKmsKeyIdOutput, error)
+}
+
+func (m *mockDoctorEC2Client) GetEbsEncryptionByDefault(ctx context.Context, input *ec2.GetEbsEncryptionByDefaultInput, optFns ...func(*ec2.Options)) (*ec2.GetEbsEncryptionByDefaultOutput, error) {
+	return m.getEbsEncryptionByDefault(ctx, input, optFns...)
+}
+
+func (m *mockDoctorEC2Client) GetEbsDefaultKmsKeyId(ctx context.Context, input *ec2.GetEbsDefaultKmsKeyIdInput, optFns ...func(*ec2.Options)) (*ec2.GetEbsDefaultKmsKeyIdOutput, error) {
+	return m.getEbsDefaultKmsKeyId(ctx, input, optFns...)
+}
+
+type mockDoctorKMSClient struct {
+	describeKey func(context.Context, *kms.DescribeKeyInput, ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+}
+
+func (m *mockDoctorKMSClient) DescribeKey(ctx context.Context, input *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	return m.describeKey(ctx, input, optFns...)
+}
+
+func TestCollectRolePolicyDocumentsIncludesInlineAndManagedPolicies(t *testing.T) {
+	t.Parallel()
+
+	roleName := "runs-on-flex-role"
+	iamClient := &mockDoctorIAMClient{
+		getRole: func(context.Context, *iam.GetRoleInput, ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+			return &iam.GetRoleOutput{Role: &iamtypes.Role{RoleName: aws.String(roleName)}}, nil
+		},
+		listRolePolicies: func(context.Context, *iam.ListRolePoliciesInput, ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+			return &iam.ListRolePoliciesOutput{PolicyNames: []string{"inline-policy"}}, nil
+		},
+		getRolePolicy: func(context.Context, *iam.GetRolePolicyInput, ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error) {
+			return &iam.GetRolePolicyOutput{PolicyDocument: aws.String(`{"Statement":[]}`)}, nil
+		},
+		listAttachedRolePolicies: func(context.Context, *iam.ListAttachedRolePoliciesInput, ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+			return &iam.ListAttachedRolePoliciesOutput{
+				AttachedPolicies: []iamtypes.AttachedPolicy{{PolicyArn: aws.String("arn:aws:iam::123456789012:policy/managed-policy")}},
+			}, nil
+		},
+		getPolicy: func(context.Context, *iam.GetPolicyInput, ...func(*iam.Options)) (*iam.GetPolicyOutput, error) {
+			return &iam.GetPolicyOutput{
+				Policy: &iamtypes.Policy{DefaultVersionId: aws.String("v1")},
+			}, nil
+		},
+		getPolicyVersion: func(context.Context, *iam.GetPolicyVersionInput, ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error) {
+			return &iam.GetPolicyVersionOutput{
+				PolicyVersion: &iamtypes.PolicyVersion{Document: aws.String(`{"Statement":[]}`)},
+			}, nil
+		},
+	}
+
+	documents, err := collectRolePolicyDocuments(context.Background(), iamClient, roleName)
+	if err != nil {
+		t.Fatalf("collectRolePolicyDocuments returned error: %v", err)
+	}
+	if len(documents) != 2 {
+		t.Fatalf("expected two policy documents, got %d", len(documents))
+	}
+}
+
+type mockDoctorIAMClient struct {
+	getRole                  func(context.Context, *iam.GetRoleInput, ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	listRolePolicies         func(context.Context, *iam.ListRolePoliciesInput, ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error)
+	getRolePolicy            func(context.Context, *iam.GetRolePolicyInput, ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error)
+	listAttachedRolePolicies func(context.Context, *iam.ListAttachedRolePoliciesInput, ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error)
+	getPolicy                func(context.Context, *iam.GetPolicyInput, ...func(*iam.Options)) (*iam.GetPolicyOutput, error)
+	getPolicyVersion         func(context.Context, *iam.GetPolicyVersionInput, ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error)
+}
+
+func (m *mockDoctorIAMClient) GetRole(ctx context.Context, input *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	return m.getRole(ctx, input, optFns...)
+}
+
+func (m *mockDoctorIAMClient) ListRolePolicies(ctx context.Context, input *iam.ListRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListRolePoliciesOutput, error) {
+	return m.listRolePolicies(ctx, input, optFns...)
+}
+
+func (m *mockDoctorIAMClient) GetRolePolicy(ctx context.Context, input *iam.GetRolePolicyInput, optFns ...func(*iam.Options)) (*iam.GetRolePolicyOutput, error) {
+	return m.getRolePolicy(ctx, input, optFns...)
+}
+
+func (m *mockDoctorIAMClient) ListAttachedRolePolicies(ctx context.Context, input *iam.ListAttachedRolePoliciesInput, optFns ...func(*iam.Options)) (*iam.ListAttachedRolePoliciesOutput, error) {
+	return m.listAttachedRolePolicies(ctx, input, optFns...)
+}
+
+func (m *mockDoctorIAMClient) GetPolicy(ctx context.Context, input *iam.GetPolicyInput, optFns ...func(*iam.Options)) (*iam.GetPolicyOutput, error) {
+	return m.getPolicy(ctx, input, optFns...)
+}
+
+func (m *mockDoctorIAMClient) GetPolicyVersion(ctx context.Context, input *iam.GetPolicyVersionInput, optFns ...func(*iam.Options)) (*iam.GetPolicyVersionOutput, error) {
+	return m.getPolicyVersion(ctx, input, optFns...)
+}
+
+func TestIAMResourceMatchesSupportsKeyWildcard(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	if !iamResourceMatches("arn:aws:kms:us-west-2:411491144243:key/*", keyARN) {
+		t.Fatal("expected wildcard key resource to match")
+	}
+	if iamResourceMatches("arn:aws:kms:us-east-1:411491144243:key/*", keyARN) {
+		t.Fatal("expected different region wildcard not to match")
+	}
+}
+
+func TestIAMCreateGrantConditionMatchesStringTrue(t *testing.T) {
+	t.Parallel()
+
+	conditions := map[string]map[string]interface{}{
+		"Bool": {"kms:GrantIsForAWSResource": "true"},
+	}
+	if !iamCreateGrantConditionMatches(conditions) {
+		t.Fatal("expected string true condition to match")
+	}
+}
+
+func TestMissingFlexRoleKMSPermissionsRejectsCreateGrantWithoutCondition(t *testing.T) {
+	t.Parallel()
+
+	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	policy := `{
+		"Statement": [{
+			"Effect": "Allow",
+			"Action": ["kms:CreateGrant", "kms:Decrypt"],
+			"Resource": "` + keyARN + `"
+		}]
+	}`
+
+	missing, err := missingFlexRoleKMSPermissions([]string{policy}, keyARN)
+	if err != nil {
+		t.Fatalf("missingFlexRoleKMSPermissions returned error: %v", err)
+	}
+	if !containsString(missing, "kms:CreateGrant") {
+		t.Fatalf("expected kms:CreateGrant to remain missing without condition, got %v", missing)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/doctor_ebs_test.go
+++ b/internal/cli/doctor_ebs_test.go
@@ -24,7 +24,7 @@ func TestFlexRoleName(t *testing.T) {
 func TestMissingFlexRoleKMSPermissionsDetectsMissingActions(t *testing.T) {
 	t.Parallel()
 
-	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	keyARN := "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 	policy := `{
 		"Statement": [{
 			"Effect": "Allow",
@@ -37,7 +37,7 @@ func TestMissingFlexRoleKMSPermissionsDetectsMissingActions(t *testing.T) {
 				"kms:ReEncryptFrom",
 				"kms:ReEncryptTo"
 			],
-			"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+			"Resource": "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 		}]
 	}`
 
@@ -53,7 +53,7 @@ func TestMissingFlexRoleKMSPermissionsDetectsMissingActions(t *testing.T) {
 func TestMissingFlexRoleKMSPermissionsAcceptsCompletePolicy(t *testing.T) {
 	t.Parallel()
 
-	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	keyARN := "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 	policy := `{
 		"Statement": [
 			{
@@ -67,12 +67,12 @@ func TestMissingFlexRoleKMSPermissionsAcceptsCompletePolicy(t *testing.T) {
 					"kms:ReEncryptFrom",
 					"kms:ReEncryptTo"
 				],
-				"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+				"Resource": "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 			},
 			{
 				"Effect": "Allow",
 				"Action": ["kms:CreateGrant"],
-				"Resource": "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd",
+				"Resource": "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd",
 				"Condition": {
 					"Bool": {
 						"kms:GrantIsForAWSResource": true
@@ -94,12 +94,12 @@ func TestMissingFlexRoleKMSPermissionsAcceptsCompletePolicy(t *testing.T) {
 func TestMissingFlexRoleKMSPermissionsMatchesWildcardResource(t *testing.T) {
 	t.Parallel()
 
-	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	keyARN := "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 	policy := `{
 		"Statement": [{
 			"Effect": "Allow",
 			"Action": "kms:*",
-			"Resource": "arn:aws:kms:us-west-2:411491144243:key/*"
+			"Resource": "arn:aws:kms:us-west-2:123456789011:key/*"
 		}]
 	}`
 
@@ -298,11 +298,11 @@ func (m *mockDoctorIAMClient) GetPolicyVersion(ctx context.Context, input *iam.G
 func TestIAMResourceMatchesSupportsKeyWildcard(t *testing.T) {
 	t.Parallel()
 
-	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
-	if !iamResourceMatches("arn:aws:kms:us-west-2:411491144243:key/*", keyARN) {
+	keyARN := "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	if !iamResourceMatches("arn:aws:kms:us-west-2:123456789011:key/*", keyARN) {
 		t.Fatal("expected wildcard key resource to match")
 	}
-	if iamResourceMatches("arn:aws:kms:us-east-1:411491144243:key/*", keyARN) {
+	if iamResourceMatches("arn:aws:kms:us-east-1:123456789011:key/*", keyARN) {
 		t.Fatal("expected different region wildcard not to match")
 	}
 }
@@ -321,7 +321,7 @@ func TestIAMCreateGrantConditionMatchesStringTrue(t *testing.T) {
 func TestMissingFlexRoleKMSPermissionsRejectsCreateGrantWithoutCondition(t *testing.T) {
 	t.Parallel()
 
-	keyARN := "arn:aws:kms:us-west-2:411491144243:key/35207482-6234-45c5-adfc-41184d40e7cd"
+	keyARN := "arn:aws:kms:us-west-2:123456789011:key/35207482-6234-45c5-adfc-41184d40e7cd"
 	policy := `{
 		"Statement": [{
 			"Effect": "Allow",


### PR DESCRIPTION
I deployed a RunsOn Flex stack with EbsEncryptionKey unset. Because our AWS account has EBS encryption by default enabled, EC2 still encrypted volumes with the account default KMS key — but <stack>-flex-role did not have permissions to use that key, so runner instances failed to launch. This was hard to spot from existing doctor output.

This PR adds a Flex-only check to roc stack doctor that resolves the EBS encryption key in use and verifies the flex role can access it.

**Key resolution**

- Reads EbsEncryptionKey from /runs-on/<stack>/stack-config
- If unset, falls back to the account’s EBS default encryption settings (EC2 APIs)
- Resolves the key via KMS and displays alias/aws/ebs when it matches the AWS-managed default

**IAM validation**

- Inspects inline and attached managed policies on <stack>-flex-role
- Verifies the required KMS actions on the resolved key ARN:
  - Decrypt, DescribeKey, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, ReEncryptFrom, ReEncryptTo
  - CreateGrant with kms:GrantIsForAWSResource: true
- Reports the key in use and any missing permissions; Fleet stacks skip this check
 
**Changes**
- New internal/cli/doctor_ebs.go with key resolution and IAM policy evaluation
- Wired into StackDoctor.Run(); documented in README and command help
- Added EbsEncryptionKey to stack config parsing
- Unit tests for policy parsing, key resolution, and Fleet skip behavior
- Added kms SDK dependency

**Test plan**

- [ x ]  go test ./internal/cli/ -run 'Doctor|FlexRole|EBS|IAM|KMS|ResolveEBS' -v

- [ x ]  roc stack doctor --stack <flex-stack> against a Flex stack with account default EBS encryption and confirm the check passes or reports missing KMS permissions

- [ ]  Confirm Fleet stacks skip the check with ⏭️ (please test this with a fleet deployment if possible)

- [ x ]  Confirm failure output lists the resolved key (e.g. alias/aws/ebs) and missing actions when permissions are incomplete
